### PR TITLE
Hide original 을 선택 해제 할때 데이터들이 계속 로딩 되는 문제를 수정

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -175,5 +175,7 @@ article {
 }
 
 .hidden {
-  display: none;
+  position: absolute !important;
+  top: -9999px !important;
+  left: -9999px !important;
 }


### PR DESCRIPTION
크롬에서 Notes on structured concurrency, or: Go statement considered harmful 을 읽을때,
Hide Original 을 체크 했다가 해제 하면 폰트등의 데이터가 계속 로드 되는 현상을 수정 했습니다.